### PR TITLE
Week 7 / Effect로 동기화, Effect가 필요하지 않는 경우 / bohye

### DIFF
--- a/bohye/board-project/src/components/board/cud/CreateUpdate.js
+++ b/bohye/board-project/src/components/board/cud/CreateUpdate.js
@@ -4,23 +4,23 @@ import Button from "../../common/button/Button";
 import { useBoardDispatch } from "../../../contexts/BoardContext";
 
 function CreateUpdate({ mode, item, onClose }) {
-  const [formData, setFormData] = useState({
-    title: "",
-    content: "",
-    creator: "",
-  });
+  const [formData, setFormData] = useState(() =>
+    mode === "update" && item
+      ? { title: item.title, content: item.content, creator: item.creator }
+      : { title: "", content: "", creator: "" }
+  );
 
   const dispatch = useBoardDispatch();
 
-  useEffect(() => {
-    if (mode === "update" && item) {
-      setFormData({
-        title: item.title || "",
-        content: item.content || "",
-        creator: item.creator || "",
-      });
-    }
-  }, [mode, item]);
+  // useEffect(() => {
+  //   if (mode === "update" && item) {
+  //     setFormData({
+  //       title: item.title || "",
+  //       content: item.content || "",
+  //       creator: item.creator || "",
+  //     });
+  //   }
+  // }, [mode, item]);
 
   const inputChangeHandler = (e) => {
     const { name, value } = e.target;


### PR DESCRIPTION
#49 
useEffect를 사용한 곳은 두 곳입니다.

1. src\components\board\Board.js
게시글 목록을 불러오는 API호출에 useEffect를 사용하였습니다.
API호출은 렌더링 이후 진행되는 사이드 이펙트에 해당되며
리액트 렌더링 순수성 유지를 위해 useEffect를 사용하여 렌더링 이후에 실행되도록 처리한 것이기에 수정하지 않았습니다.

2. src\components\board\cud\CreateUpdate.js
게시글을 새로 생성, 수정 하는 컴포넌트입니다.
기존 코드에서는 useEffect를 사용하여 mode === "update"일 때 기존 게시글 데이터를 formData 상태에 설정하고 있었습니다.
하지만 useEffect 없이도 useState의 초기값을 동적으로 설정하여 같은 동작을 구현할 수 있기 때문에 useEffect를 제거함으로 불필요한 리렌더링을 방지하도록 수정하였습니다.